### PR TITLE
Fix version file URL property

### DIFF
--- a/GameData/kOS-Addons/StockCamera/KOS-StockCamera.version
+++ b/GameData/kOS-Addons/StockCamera/KOS-StockCamera.version
@@ -1,6 +1,6 @@
 {
   "NAME": "kOS-StockCamera",
-  "URL": "https://raw.githubusercontent.com/JonnyOThan/KOS-StockCamera/master/Resources/GameData/kOS-Addons/StockCamera/kOS-StockCamera.version",
+  "URL": "https://raw.githubusercontent.com/JonnyOThan/KOS-StockCamera/master/GameData/kOS-Addons/StockCamera/KOS-StockCamera.version",
   "DOWNLOAD": "https://github.com/JonnyOThan/KOS-StockCamera/releases",
   "CHANGE_LOG_URL": "https://raw.githubusercontent.com/JonnyOThan/KOS-StockCamera/master/CHANGELOG.md",
   "GITHUB": {


### PR DESCRIPTION
```
Running NetKAN for NetKAN/kOS-StockCamera.netkan
3845 [1] WARN CKAN.NetKAN.Transformers.AvcTransformer (null) - Error fetching remote version file: The remote server returned an error: (404) Not Found.
```

Looks like there's no Resources folder in the repo, and the capitalization of kOS/KOS in the filename doesn't match.

Noticed during review of KSP-CKAN/NetKAN#8155.